### PR TITLE
Feature/cadastrar professor com turma id robson

### DIFF
--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -32,7 +32,7 @@ namespace Minos.Site.Controllers
             foreach (var turmaId in turmasId)
             {
                 
-                Turma turma = _turmaRepository.ObterTurmaPeloId(turmasId);
+                Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
                 professor.Turmas.Add(turma);
 
             }

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -33,7 +33,7 @@ namespace Minos.Site.Controllers
             {
                 Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
 
-                if (turma != null)
+                if (turma != null || turma.Id > 0)
                 {
                     professor.Turmas.Add(turma);  
                 }

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -25,6 +25,15 @@ namespace Minos.Site.Controllers
             return View();
         }
 
+        [HttpGet]
+        public IActionResult CadastrarProfessor()
+        {
+            List<Turma> turmas = _turmaRepository.ObterTurmasDesteAno();
+
+            return View(turmas);
+        }
+
+        [HttpPost]
         public IActionResult CadastrarProfessor(string nome, string sobrenome, List<int> listaDeIdDasTurmas)
         {
 

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -10,11 +10,14 @@ namespace Minos.Site.Controllers
     public class AdminController : Controller
     {
         private IProfessorRepository _professorRepository;
+        private ITurmaRepository _turmaRepository;
 
         public AdminController(
-            IProfessorRepository professorRepository)
+            IProfessorRepository professorRepository,
+            ITurmaRepository turmaRepository)
         {
             _professorRepository = professorRepository;
+            _turmaRepository = turmaRepository;
         }
 
         public IActionResult Index()
@@ -22,11 +25,11 @@ namespace Minos.Site.Controllers
             return View();
         }
 
-        public IActionResult CadastrarProfessor(string nome, string sobrenome, string serie, Grau grau)
+        public IActionResult CadastrarProfessor(string nome, string sobrenome, int turmaId)
         {
 
             Professor professor = new Professor(nome, sobrenome);
-            Turma turma = new Turma(serie, grau);
+            Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
 
             if (!professor.ValidaProfessor() || !turma.ValidaTurmas())
             {

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -31,6 +31,7 @@ namespace Minos.Site.Controllers
             Professor professor = new Professor(nome, sobrenome);
             foreach (var turmaId in turmasId)
             {
+                
                 Turma turma = _turmaRepository.ObterTurmaPeloId(turmasId);
                 professor.Turmas.Add(turma);
 

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -25,13 +25,19 @@ namespace Minos.Site.Controllers
             return View();
         }
 
-        public IActionResult CadastrarProfessor(string nome, string sobrenome, int turmaId)
+        public IActionResult CadastrarProfessor(string nome, string sobrenome, List<int> turmasId)
         {
 
             Professor professor = new Professor(nome, sobrenome);
-            Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
+            foreach (var turmaId in turmasId)
+            {
+                Turma turma = _turmaRepository.ObterTurmaPeloId(turmasId);
+                professor.Turmas.Add(turma);
 
-            if (!professor.ValidaProfessor() || !turma.ValidaTurmas())
+            }
+            
+
+            if (!professor.ValidaProfessor())
             {
                 ViewData["Message"] = "Envie os dados do professor de forma correta!";
                 return View();

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -29,21 +29,17 @@ namespace Minos.Site.Controllers
         {
 
             Professor professor = new Professor(nome, sobrenome);
-            if (listaDeIdDasTurmas.Count() <= 0) return View();
+            if (listaDeIdDasTurmas == null || listaDeIdDasTurmas.Count() == 0)
+                return View();
+
             foreach (var turmaId in listaDeIdDasTurmas)
             {
                 Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
 
-                if (turma != null && turma.Id >= 0)
-                {
-                    professor.Turmas.Add(turma);  
-                }
-                else
-                {
+                if (turma == null || turma.Id == 0)
                     return View();
-                }
-                
 
+                professor.Turmas.Add(turma);
             }
             
 

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -31,9 +31,17 @@ namespace Minos.Site.Controllers
             Professor professor = new Professor(nome, sobrenome);
             foreach (var turmaId in turmasId)
             {
-                
                 Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
-                professor.Turmas.Add(turma);
+
+                if (turma != null)
+                {
+                    professor.Turmas.Add(turma);  
+                }
+                else
+                {
+                    return View();
+                }
+                
 
             }
             

--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -25,15 +25,16 @@ namespace Minos.Site.Controllers
             return View();
         }
 
-        public IActionResult CadastrarProfessor(string nome, string sobrenome, List<int> turmasId)
+        public IActionResult CadastrarProfessor(string nome, string sobrenome, List<int> listaDeIdDasTurmas)
         {
 
             Professor professor = new Professor(nome, sobrenome);
-            foreach (var turmaId in turmasId)
+            if (listaDeIdDasTurmas.Count() <= 0) return View();
+            foreach (var turmaId in listaDeIdDasTurmas)
             {
                 Turma turma = _turmaRepository.ObterTurmaPeloId(turmaId);
 
-                if (turma != null || turma.Id > 0)
+                if (turma != null && turma.Id >= 0)
                 {
                     professor.Turmas.Add(turma);  
                 }

--- a/Minos/Minos.Site/Models/ITurmaRepository.cs
+++ b/Minos/Minos.Site/Models/ITurmaRepository.cs
@@ -7,6 +7,6 @@ namespace Minos.Site.Models
 {
     public interface ITurmaRepository
     {
-        Turma ObterTurmaPeloId(int turmaId);
+        Turma ObterTurmaPeloId(List<int> turmaId);
     }
 }

--- a/Minos/Minos.Site/Models/ITurmaRepository.cs
+++ b/Minos/Minos.Site/Models/ITurmaRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Minos.Site.Models
+{
+    public interface ITurmaRepository
+    {
+        Turma ObterTurmaPeloId(int turmaId);
+    }
+}

--- a/Minos/Minos.Site/Models/ITurmaRepository.cs
+++ b/Minos/Minos.Site/Models/ITurmaRepository.cs
@@ -7,6 +7,6 @@ namespace Minos.Site.Models
 {
     public interface ITurmaRepository
     {
-        Turma ObterTurmaPeloId(List<int> turmaId);
+        Turma ObterTurmaPeloId(int turmaId);
     }
 }

--- a/Minos/Minos.Site/Models/ITurmaRepository.cs
+++ b/Minos/Minos.Site/Models/ITurmaRepository.cs
@@ -8,5 +8,6 @@ namespace Minos.Site.Models
     public interface ITurmaRepository
     {
         Turma ObterTurmaPeloId(int turmaId);
+        List<Turma> ObterTurmasDesteAno();
     }
 }

--- a/Minos/Minos.Site/Models/Professor.cs
+++ b/Minos/Minos.Site/Models/Professor.cs
@@ -9,12 +9,13 @@ namespace Minos.Site.Models
     {
         public string Nome { get; set; }
         public string Sobrenome { get; set; }
-        public IList<Turma> Turmas { get; set; }
+        public List<Turma> Turmas { get; set; }
 
         public Professor(string nome, string sobrenome)
         {
             Nome = nome;
             Sobrenome = sobrenome;
+            Turmas = new List<Turma>();
         }
 
         public bool ValidaProfessor()

--- a/Minos/Minos.Site/Models/Turma.cs
+++ b/Minos/Minos.Site/Models/Turma.cs
@@ -12,11 +12,11 @@ namespace Minos.Site.Models
         public Grau Grau { get; set; }
         public IList<Professor> Professores { get; set; }
 
-        public Turma(string serie, Grau grau)
-        {
-            Serie = serie;
-            this.Grau = grau;
-        }
+        //public Turma(string serie, Grau grau)
+        //{
+        //    Serie = serie;
+        //    this.Grau = grau;
+        //}
         
         public bool ValidaTurmas()
         {

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -132,7 +132,6 @@ namespace Minos.UnitTests
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
 
         }
-
-
+        
     }
 }

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -57,7 +57,7 @@ namespace Minos.UnitTests
 
             //assert
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Once);
-            //turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<List<int>>())).Returns(turmaMock.Object);
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(turmaMock.Object);
 
         }
 

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -2,6 +2,7 @@
 using Minos.Site.Models;
 using Moq;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Minos.UnitTests
@@ -9,17 +10,35 @@ namespace Minos.UnitTests
     public class ProfessorControllerTests
     {
         private Mock<IProfessorRepository> professorRepositoryMock;
+        private Mock<ITurmaRepository> turmaRepositoryMock;
         private AdminController sut;
-        
+        private Mock<Turma> turmaMock;
+        private Mock<List<int>> turmaId;
+
+
+
         public void CriaMock()
         {
             this.professorRepositoryMock = new Mock<IProfessorRepository>();
+            this.turmaRepositoryMock = new Mock<ITurmaRepository>();
         }
 
         
         public void CriaAdminController()
         {
-            this.sut = new AdminController(professorRepositoryMock.Object);
+            this.sut = new AdminController(professorRepositoryMock.Object, turmaRepositoryMock.Object);
+            
+            
+        }
+
+        public void CriaTurmaMock()
+        {
+            this.turmaMock = new Mock<Turma>();
+        }
+
+        public void CriaTurmaId()
+        {
+            this.turmaId = new Mock<List<int>>();
         }
 
         [Trait("ProfessorController", "Salvar Professor")]
@@ -28,102 +47,64 @@ namespace Minos.UnitTests
         {
             //arrange
             CriaMock();
-
+            CriaTurmaMock();
+            
             //act
             CriaAdminController();
-            sut.CadastrarProfessor("Robson", "Junior", "Serie", Grau.Fundamental);
+            sut.CadastrarProfessor("Robson", "Junior", turmaId);
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<List<int>>())).Returns(turmaMock.Object);
 
             //assert
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Once);
+            
+
         }
 
         
 
-        [Trait("ProfessorController", "Deveria Não Salvar Nome Do Professor Com Numeros")]
-        [Fact(DisplayName = "Deveria Não Salvar Nome Do Professor Com Numeros")]
-        public void DeveriaNaoSalvarProfessorComNumero()
-        {
-            //arrange
-            CriaMock();
+        //[Trait("ProfessorController", "Deveria Não Salvar Nome Do Professor Com Numeros")]
+        //[Fact(DisplayName = "Deveria Não Salvar Nome Do Professor Com Numeros")]
+        //public void DeveriaNaoSalvarProfessorComNumero()
+        //{
+        //    //arrange
+        //    CriaMock();
 
-            //act
-            CriaAdminController();
+        //    //act
+        //    CriaAdminController();
 
-            sut.CadastrarProfessor("Robso2n", "Robson", "Serie", Grau.Fundamental);
+        //    sut.CadastrarProfessor("Robso2n", "Robson", 01);
             
 
-            //assert
-            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
-        }
+        //    //assert
+        //    professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+        //}
 
-        [Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Null")]
-        [Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Null")]
-        public void DeveriaNaoSalvarProfessorComNull()
-        {
-            //arrange
-            CriaMock();
-            //act
-            CriaAdminController();
-            sut.CadastrarProfessor("Robson", null, "Serie", Grau.Fundamental);
-            //assert
-            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+        //[Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Null")]
+        //[Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Null")]
+        //public void DeveriaNaoSalvarProfessorComNull()
+        //{
+        //    //arrange
+        //    CriaMock();
+        //    //act
+        //    CriaAdminController();
+        //    sut.CadastrarProfessor("Robson", null, 01);
+        //    //assert
+        //    professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
 
-        }
+        //}
 
-        [Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Vazio")]
-        [Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Vazio")]
-        public void DeveriaNaoSalvarProfessorComVazio()
-        {
-            //arrange
-            CriaMock();
-            //act
-            CriaAdminController();
-            sut.CadastrarProfessor("", "Junior", "Serie", Grau.Fundamental);
-            //assert
-            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+        //[Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Vazio")]
+        //[Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Vazio")]
+        //public void DeveriaNaoSalvarProfessorComVazio()
+        //{
+        //    //arrange
+        //    CriaMock();
+        //    //act
+        //    CriaAdminController();
+        //    sut.CadastrarProfessor("", "Junior", 01);
+        //    //assert
+        //    professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
 
-        }
-
-        [Trait("ProfessorController", "Deveria Não Salvar Professor Com Serie Vazio")]
-        [Fact(DisplayName = "Deveria Não Salvar Professor Com Serie Vazio")]
-        public void DeveriaNaoSalvarProfessorSerieVazia()
-        {
-            //arrange
-            CriaMock();
-            //act
-            CriaAdminController();
-            sut.CadastrarProfessor("Robson", "Junior", "", Grau.Fundamental);
-            //assert
-            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
-
-        }
-        [Trait("ProfessorController", "Deveria Não Salvar Professor Com Serie Null")]
-        [Fact(DisplayName = "Deveria Não Salvar Professor Com Serie Null")]
-        public void DeveriaNaoSalvarProfessorComSerieNula()
-
-        {
-            //arrange
-            CriaMock();
-            //act
-            CriaAdminController();
-            sut.CadastrarProfessor("Robson", "Junior", null, Grau.Fundamental);
-            //assert
-            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
-
-        }
-        [Trait("ProfessorController", "Deveria Não Salvar Professor Com Grau Nenhum")]
-        [Fact(DisplayName = "Deveria Não Salvar Professor Com Grau Nenhum")]
-        public void DeveriaNaoSalvarProfessorComGrauNenhum()
-
-        {
-            //arrange
-            CriaMock();
-            //act
-            CriaAdminController();
-            sut.CadastrarProfessor("Robson", "Junior", "Serie", Grau.Nenhum);
-            //assert
-            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
-
-        }
+        //}
     }
 }

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -11,10 +11,11 @@ namespace Minos.UnitTests
     {
         private Mock<IProfessorRepository> professorRepositoryMock;
         private Mock<ITurmaRepository> turmaRepositoryMock;
+        private List<int> turmaIdVazia = new List<int>();
         private AdminController sut;
         private Mock<Turma> turmaMock;
         public List<int> turmaId;
-        private Turma turmaVazia;
+        private Turma turmaNull;
 
         public void PopulaTurmaId()
         {
@@ -26,6 +27,7 @@ namespace Minos.UnitTests
         {
             this.professorRepositoryMock = new Mock<IProfessorRepository>();
             this.turmaRepositoryMock = new Mock<ITurmaRepository>();
+            
         }
 
         
@@ -48,17 +50,17 @@ namespace Minos.UnitTests
         {
             //arrange
             CriaMock();
-            CriaTurmaMock();
             PopulaTurmaId();
             
             //act
             CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
             sut.CadastrarProfessor("Robson", "Junior", turmaId);
             
 
             //assert
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Once);
-            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(turmaMock.Object);
+            
 
         }
 
@@ -75,6 +77,7 @@ namespace Minos.UnitTests
             //act
             CriaAdminController();
             turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+            //turmaId.
             sut.CadastrarProfessor("Robso2n", "Robson", turmaId);
 
 
@@ -126,12 +129,29 @@ namespace Minos.UnitTests
 
             //act
             CriaAdminController();
-            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(turmaVazia);
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(turmaNull);
             sut.CadastrarProfessor("Robson", "Junior", turmaId);
             //assert
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
 
         }
-        
+
+        [Trait("ProfessorController", "Deveria Não Salvar Com a lista de turmas passada pelo usuario sem valores atribuidos a ela")]
+        [Fact(DisplayName = "Deveria Não Salvar Com a lista de turmas passada pelo usuario sem valores atribuidos a ela")]
+        public void DeveriaNaoSalvarComAListaDeTurmasPassadaPeloUsuarioSemValoresAtribuidosAEla()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
+
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+            
+            sut.CadastrarProfessor("Robson", "Junior", turmaIdVazia);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+
+        }
     }
 }

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -13,10 +13,11 @@ namespace Minos.UnitTests
         private Mock<ITurmaRepository> turmaRepositoryMock;
         private AdminController sut;
         private Mock<Turma> turmaMock;
-        private List<int> turmaId;
+        public List<int> turmaId;
        
         public void PopulaTurmaId()
         {
+            turmaId = new List<int>();
             turmaId.Add(01);
         }
 
@@ -52,11 +53,11 @@ namespace Minos.UnitTests
             //act
             CriaAdminController();
             sut.CadastrarProfessor("Robson", "Junior", turmaId);
-            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<List<int>>())).Returns(turmaMock.Object);
+            
 
             //assert
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Once);
-            
+            //turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<List<int>>())).Returns(turmaMock.Object);
 
         }
 

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -14,7 +14,8 @@ namespace Minos.UnitTests
         private AdminController sut;
         private Mock<Turma> turmaMock;
         public List<int> turmaId;
-       
+        private Turma turmaVazia;
+
         public void PopulaTurmaId()
         {
             turmaId = new List<int>();
@@ -61,51 +62,77 @@ namespace Minos.UnitTests
 
         }
 
-        
 
-        //[Trait("ProfessorController", "Deveria Não Salvar Nome Do Professor Com Numeros")]
-        //[Fact(DisplayName = "Deveria Não Salvar Nome Do Professor Com Numeros")]
-        //public void DeveriaNaoSalvarProfessorComNumero()
-        //{
-        //    //arrange
-        //    CriaMock();
 
-        //    //act
-        //    CriaAdminController();
+        [Trait("ProfessorController", "Deveria Não Salvar Nome Do Professor Com Numeros")]
+        [Fact(DisplayName = "Deveria Não Salvar Nome Do Professor Com Numeros")]
+        public void DeveriaNaoSalvarProfessorComNumero()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
 
-        //    sut.CadastrarProfessor("Robso2n", "Robson", 01);
-            
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+            sut.CadastrarProfessor("Robso2n", "Robson", turmaId);
 
-        //    //assert
-        //    professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
-        //}
 
-        //[Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Null")]
-        //[Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Null")]
-        //public void DeveriaNaoSalvarProfessorComNull()
-        //{
-        //    //arrange
-        //    CriaMock();
-        //    //act
-        //    CriaAdminController();
-        //    sut.CadastrarProfessor("Robson", null, 01);
-        //    //assert
-        //    professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+        }
 
-        //}
+        [Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Null")]
+        [Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Null")]
+        public void DeveriaNaoSalvarProfessorComNull()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
 
-        //[Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Vazio")]
-        //[Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Vazio")]
-        //public void DeveriaNaoSalvarProfessorComVazio()
-        //{
-        //    //arrange
-        //    CriaMock();
-        //    //act
-        //    CriaAdminController();
-        //    sut.CadastrarProfessor("", "Junior", 01);
-        //    //assert
-        //    professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+            sut.CadastrarProfessor("Robson", null, turmaId);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
 
-        //}
+        }
+
+        [Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Vazio")]
+        [Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Vazio")]
+        public void DeveriaNaoSalvarProfessorComVazio()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
+
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+            sut.CadastrarProfessor("", "Junior", turmaId);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+
+        }
+
+        [Trait("ProfessorController", "Deveria Não Salvar Com a conexão com o repository retornando null")]
+        [Fact(DisplayName = "Deveria Não Salvar Com a conexão com o Repository De Turma Retornando Null")]
+        public void DeveriaNaoSalvarComAConexaoComRepositoryDeTurmaRetornandoNull()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
+
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(turmaVazia);
+            sut.CadastrarProfessor("Robson", "Junior", turmaId);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+
+        }
+
+
     }
 }

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -44,7 +44,7 @@ namespace Minos.UnitTests
         }
        
 
-        [Trait("ProfessorController", "Salvar Professor")]
+        [Trait("ProfessorController", "Cadastrar Professor")]
         [Fact(DisplayName = "Deveria Salvar Professor Chamando Repository Uma Vez")]
         public void DeveriaSalvarProfessorChamandoRepositoryUmaVez()
         {
@@ -54,7 +54,7 @@ namespace Minos.UnitTests
             
             //act
             CriaAdminController();
-            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma() { Id = 1 } );
             sut.CadastrarProfessor("Robson", "Junior", turmaId);
             
 
@@ -66,7 +66,7 @@ namespace Minos.UnitTests
 
 
 
-        [Trait("ProfessorController", "Deveria Não Salvar Nome Do Professor Com Numeros")]
+        [Trait("ProfessorController", "Cadastrar Professor")]
         [Fact(DisplayName = "Deveria Não Salvar Nome Do Professor Com Numeros")]
         public void DeveriaNaoSalvarProfessorComNumero()
         {
@@ -85,7 +85,7 @@ namespace Minos.UnitTests
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
         }
 
-        [Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Null")]
+        [Trait("ProfessorController", "Cadastrar Professor")]
         [Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Null")]
         public void DeveriaNaoSalvarProfessorComNull()
         {
@@ -102,7 +102,7 @@ namespace Minos.UnitTests
 
         }
 
-        [Trait("ProfessorController", "Deveria Não Salvar Com Nome Do Professor Vazio")]
+        [Trait("ProfessorController", "Cadastrar Professor")]
         [Fact(DisplayName = "Deveria Não Salvar Com Nome Do Professor Vazio")]
         public void DeveriaNaoSalvarProfessorComVazio()
         {
@@ -119,7 +119,7 @@ namespace Minos.UnitTests
 
         }
 
-        [Trait("ProfessorController", "Deveria Não Salvar Com a conexão com o repository retornando null")]
+        [Trait("ProfessorController", "Cadastrar Professor")]
         [Fact(DisplayName = "Deveria Não Salvar Com a conexão com o Repository De Turma Retornando Null")]
         public void DeveriaNaoSalvarComAConexaoComRepositoryDeTurmaRetornandoNull()
         {
@@ -136,7 +136,7 @@ namespace Minos.UnitTests
 
         }
 
-        [Trait("ProfessorController", "Deveria Não Salvar Com a lista de turmas passada pelo usuario sem valores atribuidos a ela")]
+        [Trait("ProfessorController", "Cadastrar Professor")]
         [Fact(DisplayName = "Deveria Não Salvar Com a lista de turmas passada pelo usuario sem valores atribuidos a ela")]
         public void DeveriaNaoSalvarComAListaDeTurmasPassadaPeloUsuarioSemValoresAtribuidosAEla()
         {
@@ -152,6 +152,41 @@ namespace Minos.UnitTests
             //assert
             professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
 
+        }
+
+        [Trait("ProfessorController", "Cadastrar Professor")]
+        [Fact(DisplayName = "Deveria Não Salvar Com a lista de turmas passada pelo usuario sem valores atribuidos a ela")]
+        public void DeveriaNaoSalvarComAListaDeTurmasPassadaIgualANuloPeloUsuario()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
+
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+
+            sut.CadastrarProfessor("Robson", "Junior", null);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
+
+        }
+        
+        [Trait("ProfessorController", "Cadastrar Professor")]
+        [Fact(DisplayName = "Deveria Nao Salvar Professor Quando Repository Retorna Instancia Turma Vazia")]
+        public void DeveriaNaoSalvarProfessorQuandoRepositoryRetornaInstanciaTurmaVazia()
+        {
+            //arrange
+            CriaMock();
+            PopulaTurmaId();
+
+            //act
+            CriaAdminController();
+            turmaRepositoryMock.Setup(x => x.ObterTurmaPeloId(It.IsAny<int>())).Returns(new Turma());
+
+            sut.CadastrarProfessor("Robson", "Junior", turmaId);
+            //assert
+            professorRepositoryMock.Verify(x => x.Salvar(It.IsAny<Professor>()), Times.Never);
         }
     }
 }

--- a/Minos/Minos.UnitTests/ProfessorControllerTests.cs
+++ b/Minos/Minos.UnitTests/ProfessorControllerTests.cs
@@ -13,9 +13,12 @@ namespace Minos.UnitTests
         private Mock<ITurmaRepository> turmaRepositoryMock;
         private AdminController sut;
         private Mock<Turma> turmaMock;
-        private Mock<List<int>> turmaId;
-
-
+        private List<int> turmaId;
+       
+        public void PopulaTurmaId()
+        {
+            turmaId.Add(01);
+        }
 
         public void CriaMock()
         {
@@ -35,11 +38,7 @@ namespace Minos.UnitTests
         {
             this.turmaMock = new Mock<Turma>();
         }
-
-        public void CriaTurmaId()
-        {
-            this.turmaId = new Mock<List<int>>();
-        }
+       
 
         [Trait("ProfessorController", "Salvar Professor")]
         [Fact(DisplayName = "Deveria Salvar Professor Chamando Repository Uma Vez")]
@@ -48,6 +47,7 @@ namespace Minos.UnitTests
             //arrange
             CriaMock();
             CriaTurmaMock();
+            PopulaTurmaId();
             
             //act
             CriaAdminController();


### PR DESCRIPTION
Corrigidos os testes que passaram por mudança ao receber mais um argumento (lista de turmas).

Criado foreach que adiciona a professor a todas as turmas que forem passadas pelo usuário, junto com isso foram criados alguns testes,  como turmas null e turmas vazias, não podendo salvar com esses tipos de dados.